### PR TITLE
Unify AWC and AVWX into a single METAR parser (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,16 @@ wheels/
 .installed.cfg
 *.egg
 
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test artifacts
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
 # Home Assistant
 .storage
 .cloud

--- a/custom_components/ha_metar_weather/api_client.py
+++ b/custom_components/ha_metar_weather/api_client.py
@@ -37,6 +37,87 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+# Numeric fields where AWC's JSON values are authoritative. The AWC API handles
+# edge formats the raw regex parser does not ("6+"/"P6SM" visibility, hPa vs inHg
+# altimeter auto-detection, epoch observation time), so we trust its numbers.
+_AWC_NUMERIC_KEYS: tuple[str, ...] = (
+    "temperature",
+    "dew_point",
+    "humidity",
+    "wind_speed",
+    "wind_direction",
+    "wind_gust",
+    "visibility",
+    "pressure",
+)
+
+
+def merge_awc_numerics(
+    parsed: Dict[str, Any], awc_meta: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Overlay AWC's authoritative numerics onto parser-derived textual data.
+
+    Textual fields (weather, clouds, trend, runway states, cavok/auto) come from
+    the shared :class:`MetarParser` so both data sources agree (issue #3). Numeric
+    fields, the real station name and the observation time are taken from AWC when
+    present. Inputs are not mutated.
+
+    Args:
+        parsed: Output of ``MetarParser(raw).get_parsed_data()``.
+        awc_meta: AWC numerics/metadata from ``parse_awc_response``.
+
+    Returns:
+        A new merged dictionary.
+    """
+    merged = deepcopy(parsed)
+
+    for key in _AWC_NUMERIC_KEYS:
+        value = awc_meta.get(key)
+        if value is None:
+            continue
+        # Only overlay an AWC numeric that is itself valid. A corrupt/out-of-range
+        # AWC value must not clobber the parser's value (derived from the same raw
+        # METAR), which would otherwise be nulled by the later range check.
+        value_range = VALUE_RANGES.get(key)
+        if value_range is not None:
+            try:
+                if not value_range[0] <= float(value) <= value_range[1]:
+                    _LOGGER.warning(
+                        "AWC %s=%s out of range for %s; keeping parser value",
+                        key,
+                        value,
+                        awc_meta.get("station_name") or "station",
+                    )
+                    continue
+            except (ValueError, TypeError):
+                _LOGGER.warning(
+                    "AWC %s=%r is not numeric for %s; keeping parser value",
+                    key,
+                    value,
+                    awc_meta.get("station_name") or "station",
+                )
+                continue
+        merged[key] = value
+
+    # The variable wind direction *range* (e.g. "180°-240°") only exists in the
+    # raw string, so keep the parser value; fall back to AWC's "VRB" marker only
+    # when the parser found nothing.
+    if (
+        merged.get("wind_variable_direction") is None
+        and awc_meta.get("wind_variable_direction") is not None
+    ):
+        merged["wind_variable_direction"] = awc_meta["wind_variable_direction"]
+
+    station_name = awc_meta.get("station_name")
+    if station_name:
+        merged["station_name"] = station_name
+
+    if awc_meta.get("observation_time") is not None:
+        merged["observation_time"] = awc_meta["observation_time"]
+
+    return merged
+
+
 class DataSource(Enum):
     """Enumeration of available data sources."""
     AWC = "awc"  # Aviation Weather Center REST API
@@ -160,8 +241,22 @@ class MetarApiClient:
         if not raw_data:
             return None
 
-        parsed = self._awc_client.parse_awc_response(raw_data)
-        return self._validate_and_round(parsed)
+        awc_meta = self._awc_client.parse_awc_response(raw_data)
+
+        raw_metar = awc_meta.get("raw_metar")
+        if not raw_metar:
+            # Without the raw METAR we cannot produce the canonical textual
+            # fields; surface it and let fetch_data() fall back to AVWX.
+            _LOGGER.warning(
+                "AWC response for %s has no raw METAR (rawOb); falling back to AVWX",
+                self.icao,
+            )
+            return None
+
+        # Single parser for all textual fields, AWC numerics overlaid on top.
+        parsed = MetarParser(raw_metar).get_parsed_data()
+        merged = merge_awc_numerics(parsed, awc_meta)
+        return self._validate_and_round(merged)
 
     async def _fetch_from_avwx(self) -> Optional[Dict[str, Any]]:
         """Fetch and parse data from AVWX (NOAA FTP).
@@ -188,9 +283,16 @@ class MetarApiClient:
             if not self._avwx_metar.raw:
                 raise MetarApiClientError("No raw METAR string from AVWX")
 
-            # Parse using our MetarParser
-            parser = MetarParser(self._avwx_metar.data)
+            # Parse using our MetarParser (raw string -> canonical dict).
+            parser = MetarParser(self._avwx_metar.raw)
             parsed_data = parser.get_parsed_data()
+
+            # Layer in the real station name from AVWX (the parser only yields
+            # the ICAO code). Fall back silently to the ICAO if unavailable.
+            station = getattr(self._avwx_metar, "station", None)
+            station_name = getattr(station, "name", None) if station else None
+            if station_name:
+                parsed_data["station_name"] = station_name
 
             # Add observation time
             # AVWX returns Timestamp object with .dt attribute, not datetime directly

--- a/custom_components/ha_metar_weather/awc_client.py
+++ b/custom_components/ha_metar_weather/awc_client.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import re
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
 
@@ -32,7 +31,7 @@ from .const import (
     AWC_API_TIMEOUT,
     DEFAULT_EXCELLENT_VISIBILITY_KM,
 )
-from .utils import calculate_humidity, parse_runway_states_from_raw
+from .utils import calculate_humidity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,8 +158,14 @@ class AWCApiClient:
             return result[0]
         return None
 
-    def parse_awc_response(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Parse AWC API response into internal format.
+    @staticmethod
+    def parse_awc_response(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract AWC's authoritative numerics and metadata.
+
+        Returns numeric fields plus raw_metar, station_name and observation_time
+        only. Textual fields (weather, clouds, trend, runway states, cavok/auto)
+        are intentionally NOT produced here: they are derived from raw_metar by
+        the shared MetarParser so the AWC and AVWX paths agree (issue #3).
 
         The AWC API returns JSON. Key fields (as of 2026):
         - obsTime: int (epoch seconds) — previously was ISO string
@@ -169,14 +174,13 @@ class AWCApiClient:
         - visib: str (statute miles, e.g. "6+", "10")
         - wspd/wgst: int (knots)
         - rawOb: str (raw METAR)
-        - clouds: list[dict] with cover/base
         - name: str (station name)
 
         Args:
             data: AWC API response data
 
         Returns:
-            Parsed data in internal format
+            Numerics/metadata dictionary (no textual weather fields)
         """
         try:
             # Parse wind data
@@ -261,22 +265,6 @@ class AWCApiClient:
                         altim, data.get("icaoId", "unknown"),
                     )
 
-            # Parse clouds (AWC API returns base already in feet)
-            # Use 'or []' because get() returns None if key exists with null value
-            # Also verify type is list to handle unexpected API changes
-            cloud_layers = []
-            clouds = data.get("clouds")
-            if isinstance(clouds, list):
-                for cloud in clouds:
-                    if isinstance(cloud, dict):
-                        cover = cloud.get("cover", "")
-                        base = cloud.get("base")
-                        cloud_layers.append({
-                            "coverage": cover,
-                            "height": base if base else None,  # Already in feet
-                            "type": cloud.get("type")
-                        })
-
             # Calculate humidity using shared utility function
             temp = data.get("temp")
             dewp = data.get("dewp")
@@ -317,21 +305,17 @@ class AWCApiClient:
                 )
                 observation_time = datetime.now(timezone.utc)
 
-            # Determine CAVOK (Ceiling And Visibility OK - visibility >= 10 km)
-            cavok = False
             raw_metar = data.get("rawOb", "")
-            if "CAVOK" in raw_metar:
-                cavok = True
-                if visibility is None:
-                    visibility = 10.0  # CAVOK means at least 10 km visibility
 
-            # Parse weather string
-            weather = data.get("wxString") or "Clear"
+            # CAVOK implies visibility of at least 10 km. The textual CAVOK flag
+            # itself is produced by the shared parser; here we only backfill the
+            # numeric so AWC's authoritative visibility stays correct.
+            if visibility is None and "CAVOK" in raw_metar:
+                visibility = 10.0
 
-            # Parse runway states from raw METAR (AWC doesn't provide this directly)
-            runway_states = parse_runway_states_from_raw(raw_metar) if raw_metar else {}
-
-            # Build parsed data
+            # Numerics and metadata only. All textual fields (weather, clouds,
+            # trend, runway states, cavok/auto) are derived by the shared
+            # MetarParser from raw_metar so both data sources agree (issue #3).
             parsed = {
                 "raw_metar": raw_metar,
                 "station_name": data.get("name"),
@@ -345,18 +329,9 @@ class AWCApiClient:
                 "wind_variable_direction": wind_variable,
                 "visibility": visibility,
                 "pressure": pressure,
-                "weather": weather,
-                "cloud_layers": cloud_layers,
-                "cloud_coverage_state": cloud_layers[0].get("coverage", "Clear") if cloud_layers else "Clear",
-                "cloud_coverage_height": cloud_layers[0].get("height") if cloud_layers else None,
-                "cloud_coverage_type": cloud_layers[0].get("type") or "N/A" if cloud_layers else "N/A",
-                "cavok": cavok,
-                "auto": "AUTO" in raw_metar,
-                "trend": None,
-                "runway_states": runway_states,
             }
 
-            _LOGGER.debug("Parsed AWC data for %s: %s", data.get("icaoId"), parsed)
+            _LOGGER.debug("Parsed AWC numerics for %s: %s", data.get("icaoId"), parsed)
             return parsed
 
         except Exception as err:

--- a/custom_components/ha_metar_weather/metar_parser.py
+++ b/custom_components/ha_metar_weather/metar_parser.py
@@ -68,10 +68,15 @@ class MetarParser:
     RUNWAY_SURFACE_CODES = RUNWAY_SURFACE_CODES
     RUNWAY_COVERAGE_CODES = RUNWAY_COVERAGE_CODES
 
-    def __init__(self, metar_data: Any):
-        """Initialize parser with METAR data."""
-        self.metar = metar_data
-        self.raw_metar = getattr(metar_data, 'raw', '')
+    def __init__(self, raw_metar: str):
+        """Initialize parser with a raw METAR string.
+
+        The parser is a pure ``raw -> dict`` transform. Both data sources (AWC
+        and AVWX) feed it the raw METAR so they produce identical textual output
+        (see issue #3). Source-specific extras (the real station name, AWC's
+        authoritative numerics) are layered in by the api_client afterwards.
+        """
+        self.raw_metar = raw_metar or ""
         # Caches for expensive parsing operations
         self._cloud_layers_cache: Optional[List[CloudLayer]] = None
         self._runway_states_cache: Optional[Dict[str, RunwayState]] = None
@@ -192,7 +197,7 @@ class MetarParser:
     def parse_weather(self) -> str:
         """Parse weather conditions."""
         try:
-            if getattr(self.metar, 'cavok', False):
+            if "CAVOK" in self.raw_metar:
                 return "CAVOK"
 
             weather_codes = []
@@ -309,52 +314,30 @@ class MetarParser:
             return "Clear"
 
     def parse_trend(self) -> Optional[str]:
-        """Parse trend information."""
-        try:
-            trend_parts = []
+        """Parse the trend/forecast group from the raw METAR.
 
-            # Check for NOSIG (No Significant Change) in raw METAR
-            if 'NOSIG' in self.raw_metar:
+        Trend is free-form forecast text, so it is returned verbatim from the
+        raw string (NOSIG, or the TEMPO/BECMG segment up to any RMK section).
+        """
+        try:
+            # Trend groups appear before any RMK section; drop remarks first so a
+            # TEMPO/BECMG token inside RMK is not mistaken for a trend.
+            body = re.split(r'\bRMK\b', self.raw_metar)[0]
+
+            # NOSIG (No Significant Change)
+            if 'NOSIG' in body:
                 return "No significant change"
 
-            if hasattr(self.metar, 'tempo'):
-                trend_parts.append(f"TEMPO {self.metar.tempo}")
-            if hasattr(self.metar, 'trend'):
-                trend_parts.append(f"TREND {self.metar.trend}")
-            if hasattr(self.metar, 'becoming'):
-                trend_parts.append(f"BECMG {self.metar.becoming}")
+            # TEMPO / BECMG forecast segment - return from the keyword to the end
+            match = re.search(r'\b(?:TEMPO|BECMG)\b', body)
+            if not match:
+                return None
 
-            return " | ".join(trend_parts) if trend_parts else None
+            segment = body[match.start():].strip()
+            return segment or None
 
         except Exception as err:
             _LOGGER.error("Error parsing trend information: %s", err)
-            return None
-
-    def _extract_numeric_value(self, value: Any) -> Optional[float]:
-        """Extract numeric value from METAR number objects."""
-        _LOGGER.debug("Extracting numeric value from: %s", value)
-
-        try:
-            if hasattr(value, 'value'):
-                val = value.value
-                # For visibility in meters, convert to appropriate units
-                if hasattr(value, 'units'):
-                    if value.units == 'm':  # if value is in meters
-                        return float(val)  # keep in meters
-                return float(val)
-
-            if isinstance(value, str):
-                if value.startswith('M'):
-                    return -float(value[1:])
-                return float(value)
-
-            if isinstance(value, (int, float)):
-                return float(value)
-
-            return None
-
-        except (ValueError, TypeError) as err:
-            _LOGGER.error("Error extracting numeric value: %s (%s)", value, err)
             return None
 
     def parse_cloud_coverage(self) -> str:
@@ -523,17 +506,11 @@ class MetarParser:
         # Parse weather phenomena using the proper method that handles intensity
         weather_description = self.parse_weather()
 
-        # Try to get station name from AVWX data
-        # AVWX may provide station info via .station attribute or .station_info
+        # The raw string only yields the ICAO code as the station name. The real
+        # airport name (when the data source provides one) is layered in by the
+        # api_client after parsing.
         station_name = None
-        if hasattr(self.metar, 'station') and self.metar.station:
-            station_name = getattr(self.metar.station, 'name', None)
-        if not station_name and hasattr(self.metar, 'station_info'):
-            station_name = getattr(self.metar.station_info, 'name', None)
-
-        # Fallback to ICAO code from raw METAR if name not available
-        if not station_name and self.raw_metar:
-            # First 4 characters of METAR are the ICAO code
+        if self.raw_metar:
             parts = self.raw_metar.split()
             if parts:
                 icao = parts[0]

--- a/docs/localization-roadmap.md
+++ b/docs/localization-roadmap.md
@@ -1,0 +1,161 @@
+# Localization roadmap (phase 2)
+
+Status: design / not yet implemented. Phase 1 (single-parser source unification, issue #3) is implemented separately and is a prerequisite for this.
+
+## Goal
+
+Make weather/cloud/runway sensor states language-independent and localized per user, the Home-Assistant-idiomatic way: the integration emits a stable machine slug as the state; HA's frontend translates it to the viewing user's language via `translations/<lang>.json`. The integration stops baking English (or any single language) prose into the state.
+
+This is what actually closes issue #3 for the reporter (French) and removes the dead `translations_data.py`. PR #2's French belongs in `translations/fr.json` under this design, not in `translations_data.py`.
+
+## Why slugs, not prose
+
+- State stays identical across languages and across both data sources, so recorder history, statistics and automations stay clean.
+- Localization is per logged-in user (frontend), not just the system language. Self-translation in Python can only ever follow `hass.config.language` (system), never per-user.
+- It is the mechanism HA core uses (e.g. DSMR: `device_class=ENUM`, `options=['low','normal']`, `translation_key`, strings under `entity.sensor.<key>.state.<slug>`).
+
+## Two mechanisms, by vocabulary type
+
+1. Finite vocabulary -> `SensorDeviceClass.ENUM` + `options=[slugs]` + `translation_key`. HA validates the value is in `options` (ValueError otherwise) and the frontend localizes it. Cannot be combined with `state_class` or `native_unit_of_measurement` (these sensors have neither, so this is fine).
+2. Compositional / open-ended (weather phenomena) -> stays a plain string sensor with a stable canonical token state; localized prose and the structured breakdown go in attributes. Do NOT force this into an ENUM: the combination space is unbounded and out-of-options values (severe weather like `+FZRASN`, `+TSGR`) would be rejected/nulled by HA.
+
+## Wiring note (important)
+
+Today the sensors set `_attr_name` manually and have NO `translation_key`, so the `entity.sensor.*` block already present in `translations/en.json` is not actually driving state translation. Phase 2 must set `translation_key` on each ENUM sensor description for state translation to take effect. The existing `entity.sensor` block is also partly stale (keys `cloud_coverage`, `report_type`, `recent_weather`, `wind_shear`, `remarks` do not match real sensor keys; `runway_state.state_attributes` lists slugs the code never emits) and should be reconciled to the real keys below.
+
+## Slug vocabulary
+
+`const.py` becomes the single source of truth for `code -> slug`. Display strings (including English) live only in `translations/<lang>.json`. Delete the per-language dicts in `translations_data.py`.
+
+### Cloud coverage (ENUM, sensor key `cloud_coverage_state`, translation_key `cloud_coverage_state`)
+
+| METAR | slug | en |
+|-------|------|----|
+| (no layers) | `clear` | Clear |
+| SKC | `skc` | Clear sky |
+| CLR | `clr` | No clouds below 12,000 ft |
+| NSC | `nsc` | No significant clouds |
+| NCD | `ncd` | No clouds detected |
+| CAVOK | `cavok` | Ceiling and visibility OK |
+| FEW | `few` | Few (1-2 oktas) |
+| SCT | `scattered` | Scattered (3-4 oktas) |
+| BKN | `broken` | Broken (5-7 oktas) |
+| OVC | `overcast` | Overcast (8 oktas) |
+| VV | `vertical_visibility` | Vertical visibility |
+
+`options` = all slugs above.
+
+### Cloud type (ENUM, sensor key `cloud_coverage_type`, translation_key `cloud_coverage_type`)
+
+| METAR | slug | en |
+|-------|------|----|
+| (none) | `none` | N/A |
+| CB | `cumulonimbus` | Cumulonimbus |
+| TCU | `towering_cumulus` | Towering Cumulus |
+| CI | `cirrus` | Cirrus |
+| CS | `cirrostratus` | Cirrostratus |
+| CC | `cirrocumulus` | Cirrocumulus |
+| AS | `altostratus` | Altostratus |
+| AC | `altocumulus` | Altocumulus |
+| NS | `nimbostratus` | Nimbostratus |
+| SC | `stratocumulus` | Stratocumulus |
+| ST | `stratus` | Stratus |
+| CU | `cumulus` | Cumulus |
+
+### Runway surface (ENUM, per-runway and `runway_states` attributes)
+
+| code | slug | en |
+|------|------|----|
+| 0 | `clear_and_dry` | Clear and dry |
+| 1 | `damp` | Damp |
+| 2 | `wet` | Wet or water patches |
+| 3 | `rime_or_frost` | Rime or frost |
+| 4 | `dry_snow` | Dry snow |
+| 5 | `wet_snow` | Wet snow |
+| 6 | `slush` | Slush |
+| 7 | `ice` | Ice |
+| 8 | `compacted_snow` | Compacted snow |
+| 9 | `frozen_ruts` | Frozen ruts or ridges |
+| / | `not_reported` | Not reported |
+| SNOCLO | `snow_closed` | Closed due to snow |
+| CLRD | `cleared` | Cleared |
+
+### Runway coverage (ENUM)
+
+| code | slug | en |
+|------|------|----|
+| 0 | `cov_0` | 0% |
+| 1 | `cov_lt10` | Less than 10% |
+| 2 | `cov_11_25` | 11-25% |
+| 3, 5 | `cov_26_50` | 26-50% |
+| 4, 6 | `cov_51_75` | 51-75% |
+| 7 | `cov_76_90` | 76-90% |
+| 8 | `cov_91_100` | 91-100% |
+| 9 | `cov_51_100` | 51-100% |
+| / | `not_reported` | Not reported |
+
+### Report type / auto (sensor key `auto_indicator`)
+
+Prefer converting to a `binary_sensor` (auto vs manual) OR an ENUM with `options=['auto','manual']`. The current `str(True)`/`str(False)` state on the `cavok` sensor is likewise better as a `binary_sensor`.
+
+| slug | en |
+|------|----|
+| `auto` | Automated report |
+| `manual` | Manual report |
+
+### Weather phenomena (NOT enum - composed token string)
+
+State = canonical token string built from the slugs below in fixed order `intensity descriptor phenomena...`, joined deterministically (e.g. `heavy thunderstorm rain`); `clear` when none. Localized prose and the structured group list (`[{intensity, descriptor, phenomena[], recent}]`) go into `extra_state_attributes`.
+
+Intensity: `-` -> `light`, `+` -> `heavy`, `VC` -> `vicinity`, (none) -> `moderate`.
+
+Descriptor: MI `shallow`, PR `partial`, BC `patches`, DR `low_drifting`, BL `blowing`, SH `showers`, TS `thunderstorm`, FZ `freezing`.
+
+Phenomena: DZ `drizzle`, RA `rain`, SN `snow`, SG `snow_grains`, IC `ice_crystals`, PL `ice_pellets`, GR `hail`, GS `small_hail`, UP `unknown_precip`, BR `mist`, FG `fog`, FU `smoke`, VA `volcanic_ash`, DU `widespread_dust`, SA `sand`, HZ `haze`, PY `spray`, PO `dust_whirls`, SQ `squalls`, FC `funnel_cloud`, SS `sandstorm`, DS `duststorm`.
+
+Recent (RE-prefixed) phenomena keep the same phenomenon slug plus a `recent: true` flag in the attribute breakdown.
+
+### Trend sensor (NOT enum)
+
+`trend` is free-form forecast text (NOSIG / TEMPO ... / BECMG ...). Leave as a plain string sensor. Do not confuse it with `ATTR_TREND` (`rising`/`falling`/`veering`/`backing`/`stable`) which already lives as a slug attribute on numeric sensors and is already translated in `translations/<lang>.json`.
+
+## Translation file structure
+
+```
+translations/en.json (and de, ru, fr):
+  entity:
+    sensor:
+      cloud_coverage_state:
+        state: { clear: "...", few: "...", scattered: "...", ... }
+      cloud_coverage_type:
+        state: { none: "...", cumulonimbus: "...", ... }
+      runway_state:
+        state_attributes:
+          surface: { state: { clear_and_dry: "...", ... } }
+          coverage: { state: { cov_0: "...", ... } }
+```
+
+French strings come from PR #2 (after a proofread: fix `Légere`->`Légère`, `Jusqu'a`->`Jusqu'à`, the leftover Russian `unknown`->`Neige`/correct French, distinct words for `ice_crystals` vs `freezing`, `spray`->`Embruns`).
+
+## Migration / breaking-change discipline
+
+Changing a sensor's state value is a one-way break: HA's recorder cannot rewrite past states, so history shows a permanent two-vocabulary split, and any automation/template/card matching the old strings (`"Light Rain"`, `"Few (1-2 oktas)"`, `"True"`) stops matching.
+
+Steps:
+1. Keep every `unique_id` and entity-description `key` unchanged. Any decomposition (e.g. splitting weather into intensity/descriptor sub-sensors) must be additive; deprecate, do not delete.
+2. Apply ENUM + `translation_key` only to the finite fields above; leave `weather`, `cloud_layers`, `runway_states` (composite) and `trend` as plain strings.
+3. Ship slugs and their en/de/ru/fr translation strings atomically in one release - otherwise users see raw slugs.
+4. Preserve numeric sensors exactly: internal base units (km/h, km, hPa, feet), `NUMERIC_PRECISION` rounding, and the `suggested_unit_of_measurement` display path. These carry `state_class=MEASUREMENT` (long-term statistics); any value/unit/rounding drift fractures LTS.
+5. Release as a major version with release notes containing the old -> new value map and the list of automations/templates/cards to update.
+6. Optionally mirror the old human string into an attribute (e.g. `weather_text`) for one transitional release so users can migrate references from state to attribute.
+7. Bump config-entry version only if `config_entry.data` shape changes (e.g. adding a language preference). Do not rewrite stored history records.
+
+## Files touched in phase 2
+
+- `const.py` - replace prose dicts with `code -> slug` maps; add `*_OPTIONS` lists for ENUM.
+- `metar_parser.py` - emit slugs/tokens instead of prose for weather/clouds/runway; keep the phase-1 raw-string interface.
+- `utils.py` - `parse_runway_states_from_raw` emits slugs, not prose.
+- `sensor.py` - set `device_class=ENUM`, `options`, `translation_key` on finite sensors; weather state = token string, prose+breakdown in attributes; reconcile keys.
+- `translations/en.json`, `de.json`, `ru.json`, new `fr.json` - `entity.sensor.<key>.state.<slug>` blocks.
+- delete `translations_data.py`.
+- add unit tests: raw METAR -> slug-canonical dict.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration: make the custom_components package importable."""
+
+import sys
+from pathlib import Path
+
+# Repo root holds the implicit-namespace package `custom_components`.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_metar_parser.py
+++ b/tests/test_metar_parser.py
@@ -1,0 +1,128 @@
+"""Unit tests for MetarParser.
+
+The parser is a pure ``raw METAR string -> dict`` transform. These tests pin
+the textual (weather / clouds / trend / runway) and numeric output so both the
+AWC and AVWX data paths can rely on a single parser (see issue #3).
+"""
+
+import pytest
+
+from custom_components.ha_metar_weather.metar_parser import MetarParser
+
+
+def parse(raw: str) -> dict:
+    return MetarParser(raw).get_parsed_data()
+
+
+def test_parser_accepts_raw_string():
+    """MetarParser is constructed from a raw METAR string, not an object."""
+    data = parse("KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992")
+    assert data["raw_metar"] == "KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992"
+
+
+def test_light_rain_weather():
+    data = parse("KJFK 121651Z 18010KT 10SM -RA FEW020 BKN040 22/18 A2992")
+    assert data["weather"] == "Light Rain"
+
+
+def test_heavy_thunderstorm_rain():
+    data = parse("UUEE 121630Z 24008MPS 9999 +TSRA SCT020CB BKN040 18/12 Q1009 NOSIG")
+    assert data["weather"] == "Heavy Thunderstorm Rain"
+
+
+def test_shower_rain_descriptor():
+    data = parse("EGLL 121620Z 25015KT 9999 SHRA BKN012 14/11 Q1007")
+    assert data["weather"] == "Shower Rain"
+
+
+def test_no_weather_is_clear():
+    data = parse("KLAX 121653Z 26012KT 10SM 24/12 A3001")
+    assert data["weather"] == "Clear"
+
+
+def test_cavok_weather():
+    data = parse("EGLL 121620Z 25015KT CAVOK 15/08 Q1020")
+    assert data["weather"] == "CAVOK"
+    assert data["cavok"] is True
+
+
+def test_cloud_coverage_state_is_first_layer():
+    data = parse("KJFK 121651Z 18010KT 10SM -RA FEW020 BKN040 22/18 A2992")
+    assert data["cloud_coverage_state"] == "Few (1-2 oktas)"
+
+
+def test_cloud_layers_height_and_type():
+    data = parse("UUEE 121630Z 24008MPS 9999 +TSRA SCT020CB BKN040 18/12 Q1009 NOSIG")
+    layers = data["cloud_layers"]
+    assert layers[0]["coverage"] == "Scattered (3-4 oktas)"
+    assert layers[0]["height"] == 2000
+    assert layers[0]["type"] == "Cumulonimbus"
+
+
+def test_trend_nosig():
+    data = parse("UUEE 121630Z 24008MPS 9999 BKN040 18/12 Q1009 NOSIG")
+    assert data["trend"] == "No significant change"
+
+
+def test_trend_tempo_segment():
+    data = parse("EGLL 121620Z 25015KT 9999 BKN020 14/11 Q1007 TEMPO 4000 RA BKN012")
+    assert data["trend"] is not None
+    assert data["trend"].startswith("TEMPO")
+    assert "4000" in data["trend"]
+
+
+def test_trend_none_when_absent():
+    data = parse("KLAX 121653Z 26012KT 10SM 24/12 A3001")
+    assert data["trend"] is None
+
+
+def test_trend_ignores_tempo_inside_rmk():
+    """TEMPO/BECMG appearing inside the RMK section is not a trend group."""
+    data = parse("KJFK 121651Z 18010KT 10SM BKN040 22/18 A2992 RMK AO2 TEMPO TOKEN")
+    assert data["trend"] is None
+
+
+def test_numeric_temperature_dew():
+    data = parse("KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992")
+    assert data["temperature"] == pytest.approx(22.0)
+    assert data["dew_point"] == pytest.approx(18.0)
+
+
+def test_numeric_pressure_inhg_to_hpa():
+    data = parse("KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992")
+    # A2992 = 29.92 inHg -> hPa
+    assert data["pressure"] == pytest.approx(1013.2, abs=0.1)
+
+
+def test_numeric_pressure_qnh():
+    data = parse("UUEE 121630Z 24008MPS 9999 BKN040 18/12 Q1009 NOSIG")
+    assert data["pressure"] == pytest.approx(1009.0)
+
+
+def test_numeric_wind_knots_to_kmh():
+    data = parse("KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992")
+    assert data["wind_direction"] == pytest.approx(180.0)
+    # 10 kt * 1.852
+    assert data["wind_speed"] == pytest.approx(18.5, abs=0.1)
+
+
+def test_visibility_statute_miles():
+    data = parse("KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992")
+    # 10 SM * 1.60934
+    assert data["visibility"] == pytest.approx(16.1, abs=0.1)
+
+
+def test_runway_state_parsed():
+    data = parse("UUEE 121630Z 24008MPS 9999 BKN040 18/12 Q1009 R06R/290060 NOSIG")
+    runways = data["runway_states"]
+    assert "06R" in runways
+    assert runways["06R"]["friction"] == pytest.approx(0.6)
+
+
+def test_station_name_falls_back_to_icao():
+    """With only a raw string, the parser yields the ICAO as the name.
+
+    The real airport name is layered in by the api_client from the source.
+    """
+    data = parse("KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992")
+    assert data["station_name"] == "KJFK"

--- a/tests/test_source_consistency.py
+++ b/tests/test_source_consistency.py
@@ -1,0 +1,157 @@
+"""Regression tests for issue #3: AWC and AVWX must produce identical output.
+
+The bug: the AWC (primary) path emitted raw codes ("-RA", "FEW") while the AVWX
+(fallback) path emitted parsed prose ("Light Rain", "Few (1-2 oktas)"), so the
+sensor state flipped representation depending on which source served the cycle.
+
+The fix: BOTH paths derive every textual field from the same MetarParser fed by
+the raw METAR. The AWC path then overlays AWC's authoritative numeric values.
+``merge_awc_numerics`` is that overlay step; this module proves the invariant.
+"""
+
+import pytest
+
+from custom_components.ha_metar_weather.metar_parser import MetarParser
+from custom_components.ha_metar_weather.api_client import merge_awc_numerics
+from custom_components.ha_metar_weather.awc_client import AWCApiClient
+
+
+RAW = "KJFK 121651Z 18010KT 10SM -RA FEW020 BKN040 22/18 A2992"
+
+# What AWC's JSON would give us for the same observation: authoritative numerics
+# plus the real station name and observation time. No textual fields.
+AWC_META = {
+    "raw_metar": RAW,
+    "station_name": "John F Kennedy Intl",
+    "observation_time": "2026-06-12T16:51:00+00:00",
+    "temperature": 22.0,
+    "dew_point": 18.0,
+    "humidity": 78.0,
+    "wind_speed": 18.5,
+    "wind_direction": 180.0,
+    "wind_gust": None,
+    "wind_variable_direction": None,
+    "visibility": 16.1,
+    "pressure": 1013.0,
+}
+
+
+def test_textual_fields_identical_across_sources():
+    """Weather/clouds/trend/runway are byte-identical whatever the source."""
+    parsed = MetarParser(RAW).get_parsed_data()
+    merged = merge_awc_numerics(parsed, AWC_META)
+
+    for field in (
+        "weather",
+        "cloud_coverage_state",
+        "cloud_coverage_type",
+        "cloud_layers",
+        "trend",
+        "runway_states",
+        "cavok",
+    ):
+        assert merged[field] == parsed[field], f"textual field {field} diverged"
+
+    # And the concrete value the user reported as broken:
+    assert merged["weather"] == "Light Rain"
+    assert merged["cloud_coverage_state"] == "Few (1-2 oktas)"
+
+
+def test_numeric_fields_come_from_awc():
+    """AWC numerics are authoritative (they handle 6+, hPa/inHg, epoch, etc.)."""
+    parsed = MetarParser(RAW).get_parsed_data()
+    merged = merge_awc_numerics(parsed, AWC_META)
+
+    assert merged["pressure"] == 1013.0  # AWC value, not the inHg-from-raw value
+    assert merged["visibility"] == 16.1
+    assert merged["temperature"] == 22.0
+    assert merged["humidity"] == 78.0
+
+
+def test_station_name_and_time_preserved_from_awc():
+    parsed = MetarParser(RAW).get_parsed_data()
+    merged = merge_awc_numerics(parsed, AWC_META)
+
+    assert merged["station_name"] == "John F Kennedy Intl"
+    assert merged["observation_time"] == "2026-06-12T16:51:00+00:00"
+
+
+def test_missing_awc_numeric_keeps_parser_value():
+    """If AWC omits a numeric, the parser's raw-derived value is kept."""
+    parsed = MetarParser(RAW).get_parsed_data()
+    awc_no_pressure = {k: v for k, v in AWC_META.items() if k != "pressure"}
+    merged = merge_awc_numerics(parsed, awc_no_pressure)
+
+    assert merged["pressure"] == parsed["pressure"]
+
+
+def test_out_of_range_awc_numeric_falls_back_to_parser():
+    """A corrupt AWC numeric must not clobber a valid parser-derived value.
+
+    Otherwise the later range check in _validate_and_round would null the field
+    and the sensor would go unavailable despite correct data being available.
+    """
+    parsed = MetarParser(RAW).get_parsed_data()
+    bad_awc = dict(AWC_META)
+    bad_awc["pressure"] = 5000.0  # absurd; outside VALUE_RANGES (900-1100 hPa)
+    merged = merge_awc_numerics(parsed, bad_awc)
+
+    assert merged["pressure"] == parsed["pressure"]
+    assert merged["pressure"] != 5000.0
+
+
+def test_non_numeric_awc_value_falls_back_to_parser():
+    parsed = MetarParser(RAW).get_parsed_data()
+    bad_awc = dict(AWC_META)
+    bad_awc["temperature"] = "garbage"
+    merged = merge_awc_numerics(parsed, bad_awc)
+
+    assert merged["temperature"] == parsed["temperature"]
+
+
+def test_real_awc_path_matches_parser():
+    """Exercise the real production path: parse_awc_response -> merge.
+
+    Builds a realistic AWC JSON payload, runs it through the actual
+    ``parse_awc_response`` (not a hand-written meta dict), and proves the merged
+    result is textually identical to a plain parser run on the same raw METAR.
+    """
+    awc_json = {
+        "icaoId": "UUEE",
+        "name": "Sheremetyevo",
+        "rawOb": "UUEE 121630Z 24008MPS 9999 +TSRA SCT020CB BKN040 18/12 Q1009 NOSIG",
+        "obsTime": 1781000000,
+        "temp": 18,
+        "dewp": 12,
+        "wdir": 240,
+        "wspd": 16,
+        "visib": "6+",
+        "altim": 1009,
+    }
+
+    awc_meta = AWCApiClient.parse_awc_response(awc_json)
+    assert "weather" not in awc_meta  # textual must not leak from AWC
+
+    parsed = MetarParser(awc_json["rawOb"]).get_parsed_data()
+    merged = merge_awc_numerics(parsed, awc_meta)
+
+    for field in (
+        "weather",
+        "cloud_coverage_state",
+        "cloud_coverage_type",
+        "trend",
+        "runway_states",
+        "cavok",
+    ):
+        assert merged[field] == parsed[field]
+
+    assert merged["weather"] == "Heavy Thunderstorm Rain"
+    assert merged["pressure"] == 1009.0
+    assert merged["station_name"] == "Sheremetyevo"
+
+
+def test_merge_does_not_mutate_inputs():
+    parsed = MetarParser(RAW).get_parsed_data()
+    parsed_before = dict(parsed)
+    merge_awc_numerics(parsed, AWC_META)
+    assert parsed == parsed_before


### PR DESCRIPTION
## Problem (issue #3)

Weather/cloud text was "sometimes translated, sometimes not". The AWC primary path emitted raw METAR codes ("-RA", "FEW"); the AVWX fallback emitted parsed prose ("Light Rain", "Few (1-2 oktas)"). The sensor state flipped representation depending on which source served each 30-minute cycle.

## Fix

Both paths now derive every textual field (weather, clouds, trend, runway state, cavok/auto) from one `MetarParser` fed by the raw METAR, so output is identical regardless of source. AWC's authoritative numerics (visibility "6+"/P6SM, hPa/inHg altimeter, epoch time) are overlaid via `merge_awc_numerics`, which drops any AWC value that fails its `VALUE_RANGES` check so it cannot clobber a valid parsed value.

- `MetarParser` now takes a raw string instead of an AVWX object (pure `raw -> dict`).
- `awc_client.parse_awc_response` returns numerics/metadata only (textual fields removed).

## Scope

This makes the text consistent, but English-only. Per-language translation (FR/DE/RU, incl. PR #2) is phase 2 using Home Assistant's native state-translation mechanism - see `docs/localization-roadmap.md`. Issue #3 stays open until phase 2 lands.

## Test plan

- New `tests/`: parser behavior + source-consistency (proves AWC text == AVWX text). 27 tests pass; semgrep clean.
