### PR TITLE
Fix unit preferences (#7) and AWC clobbering exact raw-METAR values (#8)

### DIFF
--- a/custom_components/ha_metar_weather/api_client.py
+++ b/custom_components/ha_metar_weather/api_client.py
@@ -28,6 +28,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .awc_client import AWCApiClient, AWCApiError
 from .metar_parser import MetarParser
+from .utils import calculate_humidity
 from .const import (
     VALUE_RANGES,
     NUMERIC_PRECISION,
@@ -37,13 +38,21 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-# Numeric fields where AWC's JSON values are authoritative. The AWC API handles
-# edge formats the raw regex parser does not ("6+"/"P6SM" visibility, hPa vs inHg
-# altimeter auto-detection, epoch observation time), so we trust its numbers.
-_AWC_NUMERIC_KEYS: tuple[str, ...] = (
+# Numeric fields where AWC's JSON is authoritative: AWC is never worse than
+# the whole degrees of the raw 16/06 group and may carry T-group decimals the
+# parser does not read.
+_AWC_AUTHORITATIVE_KEYS: tuple[str, ...] = (
     "temperature",
     "dew_point",
-    "humidity",
+)
+
+# Numeric fields where the raw METAR is exact while AWC's JSON is quantized or
+# capped: visibility in statute miles ("6+" turns 9999/CAVOK = 10 km into
+# 9.7 km - issue #8), winds in whole knots (lossy for MPS stations), altimeter
+# as int hPa (lossy for US A-group reports). The parser value wins; AWC only
+# fills gaps: a visibility group missing from the report entirely, or a
+# garbled/out-of-range token the parser rejected.
+_AWC_FALLBACK_KEYS: tuple[str, ...] = (
     "wind_speed",
     "wind_direction",
     "wind_gust",
@@ -52,15 +61,28 @@ _AWC_NUMERIC_KEYS: tuple[str, ...] = (
 )
 
 
+def _is_usable(key: str, value: Any) -> bool:
+    """True if the value would survive the VALUE_RANGES check for this key."""
+    value_range = VALUE_RANGES.get(key)
+    if value_range is None:
+        return True
+    try:
+        return value_range[0] <= float(value) <= value_range[1]
+    except (ValueError, TypeError):
+        return False
+
+
 def merge_awc_numerics(
     parsed: Dict[str, Any], awc_meta: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """Overlay AWC's authoritative numerics onto parser-derived textual data.
+    """Merge AWC numerics into parser-derived data.
 
     Textual fields (weather, clouds, trend, runway states, cavok/auto) come from
-    the shared :class:`MetarParser` so both data sources agree (issue #3). Numeric
-    fields, the real station name and the observation time are taken from AWC when
-    present. Inputs are not mutated.
+    the shared :class:`MetarParser` so both data sources agree (issue #3).
+    Temperature/dew point are taken from AWC when present; the remaining numerics
+    keep the exact parser value and use AWC only as a fallback (issue #8).
+    Humidity is recomputed from the merged temperature/dew point pair. The real
+    station name and the observation time come from AWC. Inputs are not mutated.
 
     Args:
         parsed: Output of ``MetarParser(raw).get_parsed_data()``.
@@ -71,33 +93,35 @@ def merge_awc_numerics(
     """
     merged = deepcopy(parsed)
 
-    for key in _AWC_NUMERIC_KEYS:
+    for key in _AWC_AUTHORITATIVE_KEYS + _AWC_FALLBACK_KEYS:
         value = awc_meta.get(key)
         if value is None:
             continue
+        if key in _AWC_FALLBACK_KEYS:
+            # A parser value the later range check would null anyway counts
+            # as absent - let a valid AWC value fill it (e.g. a garbled
+            # Q-group misread as 10133 hPa).
+            parser_value = merged.get(key)
+            if parser_value is not None and _is_usable(key, parser_value):
+                continue
         # Only overlay an AWC numeric that is itself valid. A corrupt/out-of-range
         # AWC value must not clobber the parser's value (derived from the same raw
         # METAR), which would otherwise be nulled by the later range check.
-        value_range = VALUE_RANGES.get(key)
-        if value_range is not None:
-            try:
-                if not value_range[0] <= float(value) <= value_range[1]:
-                    _LOGGER.warning(
-                        "AWC %s=%s out of range for %s; keeping parser value",
-                        key,
-                        value,
-                        awc_meta.get("station_name") or "station",
-                    )
-                    continue
-            except (ValueError, TypeError):
-                _LOGGER.warning(
-                    "AWC %s=%r is not numeric for %s; keeping parser value",
-                    key,
-                    value,
-                    awc_meta.get("station_name") or "station",
-                )
-                continue
+        if not _is_usable(key, value):
+            _LOGGER.warning(
+                "AWC %s=%r out of range or not numeric for %s; keeping parser value",
+                key,
+                value,
+                awc_meta.get("station_name") or "station",
+            )
+            continue
         merged[key] = value
+
+    # Humidity is derived, not observed: keep it consistent with whichever
+    # temperature/dew point pair won the merge.
+    humidity = calculate_humidity(merged.get("temperature"), merged.get("dew_point"))
+    if humidity is not None:
+        merged["humidity"] = humidity
 
     # The variable wind direction *range* (e.g. "180°-240°") only exists in the
     # raw string, so keep the parser value; fall back to AWC's "VRB" marker only

--- a/custom_components/ha_metar_weather/awc_client.py
+++ b/custom_components/ha_metar_weather/awc_client.py
@@ -193,8 +193,13 @@ class AWCApiClient:
             if wind_direction == "VRB" or wind_direction is None:
                 wind_variable = "VRB" if wind_direction == "VRB" else None
                 wind_direction = None
+            elif wind_direction == 0 and not data.get("wspd"):
+                # Calm wind (00000KT): AWC sends wdir=0/wspd=0, but direction
+                # has no meaning - mirror the parser, which yields None.
+                wind_direction = None
             else:
-                wind_direction = float(wind_direction) if wind_direction else None
+                # Not None here; plain float() keeps a valid 0 (north) intact
+                wind_direction = float(wind_direction)
 
             # Convert wind speed from knots to km/h
             if wind_speed is not None:

--- a/custom_components/ha_metar_weather/manifest.json
+++ b/custom_components/ha_metar_weather/manifest.json
@@ -15,5 +15,5 @@
     "certifi>=2024.2.2"
   ],
   "single_config_entry": false,
-  "version": "4.0.0"
+  "version": "4.0.1"
 }

--- a/custom_components/ha_metar_weather/metar_parser.py
+++ b/custom_components/ha_metar_weather/metar_parser.py
@@ -468,9 +468,10 @@ class MetarParser:
                         _LOGGER.debug("Parsed SM visibility: %s SM = %s km", vis_miles, visibility)
                         break
 
-                    # Check for fractional SM format (e.g., 1/2SM, 1/4SM, 3/4SM)
+                    # Check for fractional SM format (e.g., 1/2SM, M1/4SM, 3/4SM).
+                    # M prefix = "less than"; report the boundary value.
                     # Also handles mixed fractions where previous part is whole number
-                    frac_sm_match = re.match(r'^(\d+)/(\d+)SM$', part)
+                    frac_sm_match = re.match(r'^M?(\d+)/(\d+)SM$', part)
                     if frac_sm_match:
                         numerator = float(frac_sm_match.group(1))
                         denominator = float(frac_sm_match.group(2))
@@ -747,8 +748,14 @@ class MetarParser:
                     if len(temp_str) > 3 or len(dew_str) > 3:
                         continue
 
-                    temp_val = float(temp_str.replace('M', '-'))
-                    dew_val = float(dew_str.replace('M', '-'))
+                    try:
+                        temp_val = float(temp_str.replace('M', '-'))
+                        dew_val = float(dew_str.replace('M', '-'))
+                    except ValueError:
+                        # Token merely looked like temp/dew: fractional
+                        # visibility "1/2SM" splits to "1"/"2SM". Keep
+                        # scanning for the real group.
+                        continue
 
                     # Validate value ranges
                     if not -100 <= temp_val <= 60:

--- a/custom_components/ha_metar_weather/sensor.py
+++ b/custom_components/ha_metar_weather/sensor.py
@@ -8,7 +8,7 @@ Sensor platform for HA METAR Weather integration.
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional, Callable, Union
+from typing import Any, Mapping, Optional, Callable, Union
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (
@@ -25,6 +25,7 @@ from homeassistant.const import (
     UnitOfSpeed,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -54,11 +55,6 @@ from .const import (
     UNIT_AUTO,
     UNIT_NATIVE,
     NATIVE_METAR_UNITS,
-    DEFAULT_TEMP_UNIT,
-    DEFAULT_WIND_SPEED_UNIT,
-    DEFAULT_VISIBILITY_UNIT,
-    DEFAULT_PRESSURE_UNIT,
-    DEFAULT_ALTITUDE_UNIT,
     TrendState,
     MAX_HISTORY_DISPLAY,
     CLOUD_COVERAGE_OPTIONS,
@@ -69,6 +65,95 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# Sensor key -> config entry key holding the unit preference for it.
+_UNIT_CONF_KEYS: dict[str, str] = {
+    "temperature": CONF_TEMP_UNIT,
+    "dew_point": CONF_TEMP_UNIT,
+    "wind_speed": CONF_WIND_SPEED_UNIT,
+    "wind_gust": CONF_WIND_SPEED_UNIT,
+    "visibility": CONF_VISIBILITY_UNIT,
+    "pressure": CONF_PRESSURE_UNIT,
+    "cloud_coverage_height": CONF_ALTITUDE_UNIT,
+}
+
+# Config entry key -> NATIVE_METAR_UNITS key.
+_NATIVE_UNIT_KEYS: dict[str, str] = {
+    CONF_TEMP_UNIT: "temperature",
+    CONF_WIND_SPEED_UNIT: "wind_speed",
+    CONF_VISIBILITY_UNIT: "visibility",
+    CONF_PRESSURE_UNIT: "pressure",
+    CONF_ALTITUDE_UNIT: "altitude",
+}
+
+
+def resolve_display_unit(entry_data: Mapping[str, Any], sensor_key: str) -> Optional[str]:
+    """Resolve the configured display unit for a sensor.
+
+    Returns None for "auto" (HA's own unit-system default) and for sensors
+    without a configurable unit.
+    """
+    conf_key = _UNIT_CONF_KEYS.get(sensor_key)
+    if conf_key is None or sensor_key in FIXED_UNITS:
+        return None
+
+    configured = entry_data.get(conf_key, UNIT_AUTO)
+    if configured == UNIT_AUTO:
+        return None
+    if configured == UNIT_NATIVE:
+        return NATIVE_METAR_UNITS[_NATIVE_UNIT_KEYS[conf_key]]
+    return configured
+
+
+def sync_registry_suggested_unit(
+    ent_reg: er.EntityRegistry,
+    hass: HomeAssistant,
+    station: str,
+    description: SensorEntityDescription,
+    resolved_unit: Optional[str],
+) -> None:
+    """Push the configured unit into an already-registered entity.
+
+    HA core reads ``suggested_unit_of_measurement`` only when an entity is
+    first registered and pins it in ``options["sensor.private"]`` forever
+    (issue #7); changing the suggestion later has no effect. So on every
+    setup we rewrite the stored value ourselves. A unit the user picked
+    manually in the HA UI (``options["sensor"]["unit_of_measurement"]``)
+    always wins and is never touched.
+    """
+    if description.key not in _UNIT_CONF_KEYS:
+        return
+
+    unique_id = f"{DOMAIN}_{station}_{description.key}"
+    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+    if entity_id is None:
+        return  # new entity: __init__ provides the suggestion
+
+    entry = ent_reg.entities[entity_id]
+    if (entry.options.get("sensor") or {}).get("unit_of_measurement"):
+        return
+
+    # For "auto", mirror what core itself would store at first registration:
+    # the unit system's converted unit, or nothing when the native unit
+    # already matches the system.
+    wanted = resolved_unit or hass.config.units.get_converted_unit(
+        description.device_class, description.native_unit_of_measurement
+    )
+    stored = (entry.options.get("sensor.private") or {}).get(
+        "suggested_unit_of_measurement"
+    )
+    if stored == wanted:
+        return
+
+    _LOGGER.debug(
+        "Updating display unit for %s: %s -> %s", entity_id, stored, wanted
+    )
+    ent_reg.async_update_entity_options(
+        entity_id,
+        "sensor.private",
+        {"suggested_unit_of_measurement": wanted} if wanted else {},
+    )
 
 
 @dataclass
@@ -150,7 +235,9 @@ SENSOR_TYPES: tuple[MetarSensorEntityDescription, ...] = (
         key="pressure",
         name="Pressure",
         native_unit_of_measurement=UnitOfPressure.HPA,
-        device_class=SensorDeviceClass.PRESSURE,
+        # QNH is atmospheric pressure; plain PRESSURE would make HA's unit
+        # system pick psi instead of inHg on US installs.
+        device_class=SensorDeviceClass.ATMOSPHERIC_PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("pressure"),
         icon="mdi:gauge",
@@ -279,6 +366,7 @@ class MetarSensor(CoordinatorEntity, SensorEntity):
         station: str,
         description: MetarSensorEntityDescription,
         config_entry: ConfigEntry,
+        suggested_unit: Optional[str] = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -288,6 +376,11 @@ class MetarSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{DOMAIN}_{station}_{description.key}"
         self._attr_name = f"METAR {station} {description.name}"
         self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        # Must be set before the entity is added: HA core reads the suggested
+        # unit during registration, never after (issue #7). None = "auto",
+        # core falls back to the unit system's preferred unit.
+        if suggested_unit is not None:
+            self._attr_suggested_unit_of_measurement = suggested_unit
 
         # Add device_info
         self._attr_device_info = {
@@ -298,99 +391,6 @@ class MetarSensor(CoordinatorEntity, SensorEntity):
             "sw_version": VERSION,
             "entry_type": DeviceEntryType.SERVICE,
         }
-
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to hass."""
-        await super().async_added_to_hass()
-        self._update_units()
-
-    def _get_configured_unit(self, unit_key: str, default: str) -> str:
-        """Get configured unit from config entry or return default.
-
-        Args:
-            unit_key: Configuration key for the unit
-            default: Default unit value
-
-        Returns:
-            The configured unit or resolved auto/native unit
-        """
-        configured = self._config_entry.data.get(unit_key, UNIT_AUTO)
-
-        if configured == UNIT_AUTO:
-            # Use Home Assistant system settings
-            is_metric = self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS
-
-            if unit_key == CONF_TEMP_UNIT:
-                return UnitOfTemperature.CELSIUS if is_metric else UnitOfTemperature.FAHRENHEIT
-            elif unit_key == CONF_WIND_SPEED_UNIT:
-                return UnitOfSpeed.KILOMETERS_PER_HOUR if is_metric else UnitOfSpeed.MILES_PER_HOUR
-            elif unit_key == CONF_VISIBILITY_UNIT:
-                return UnitOfLength.KILOMETERS if is_metric else UnitOfLength.MILES
-            elif unit_key == CONF_PRESSURE_UNIT:
-                return UnitOfPressure.HPA if is_metric else UnitOfPressure.INHG
-            elif unit_key == CONF_ALTITUDE_UNIT:
-                return UnitOfLength.METERS if is_metric else UnitOfLength.FEET
-
-            return default
-
-        if configured == UNIT_NATIVE:
-            # Use native METAR/aviation units
-            native_key_mapping = {
-                CONF_TEMP_UNIT: "temperature",
-                CONF_WIND_SPEED_UNIT: "wind_speed",
-                CONF_VISIBILITY_UNIT: "visibility",
-                CONF_PRESSURE_UNIT: "pressure",
-                CONF_ALTITUDE_UNIT: "altitude",
-            }
-            native_key = native_key_mapping.get(unit_key)
-            if native_key and native_key in NATIVE_METAR_UNITS:
-                return NATIVE_METAR_UNITS[native_key]
-            return default
-
-        return configured
-
-    def _update_units(self) -> None:
-        """Update suggested display units based on configuration preferences.
-
-        Note: native_unit_of_measurement stays as defined in SENSOR_TYPES
-        (the actual unit of stored data). suggested_unit_of_measurement
-        tells Home Assistant what unit to convert to for display.
-        """
-        key = self.entity_description.key
-
-        # Skip update for sensors with fixed units
-        if key in FIXED_UNITS:
-            return
-
-        # Map sensor keys to unit configuration keys
-        unit_key_mapping = {
-            "temperature": CONF_TEMP_UNIT,
-            "dew_point": CONF_TEMP_UNIT,
-            "wind_speed": CONF_WIND_SPEED_UNIT,
-            "wind_gust": CONF_WIND_SPEED_UNIT,
-            "visibility": CONF_VISIBILITY_UNIT,
-            "pressure": CONF_PRESSURE_UNIT,
-            "cloud_coverage_height": CONF_ALTITUDE_UNIT,
-        }
-
-        default_mapping = {
-            "temperature": DEFAULT_TEMP_UNIT,
-            "dew_point": DEFAULT_TEMP_UNIT,
-            "wind_speed": DEFAULT_WIND_SPEED_UNIT,
-            "wind_gust": DEFAULT_WIND_SPEED_UNIT,
-            "visibility": DEFAULT_VISIBILITY_UNIT,
-            "pressure": DEFAULT_PRESSURE_UNIT,
-            "cloud_coverage_height": DEFAULT_ALTITUDE_UNIT,
-        }
-
-        if key in unit_key_mapping:
-            unit_key = unit_key_mapping[key]
-            default = default_mapping[key]
-            suggested_unit = self._get_configured_unit(unit_key, default)
-            # Only set suggested unit if it differs from native unit
-            # Home Assistant will handle the conversion automatically
-            if suggested_unit != self.entity_description.native_unit_of_measurement:
-                self._attr_suggested_unit_of_measurement = suggested_unit
 
     @property
     def native_value(self) -> Optional[Union[str, float, int]]:
@@ -575,6 +575,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the METAR sensors."""
     coordinators = hass.data[DOMAIN][config_entry.entry_id]
+    ent_reg = er.async_get(hass)
     entities: list[MetarSensor] = []
 
     for station in config_entry.data[CONF_STATIONS]:
@@ -597,11 +598,16 @@ async def async_setup_entry(
         _LOGGER.debug("Setting up sensors for station %s", station_upper)
 
         for description in SENSOR_TYPES:
+            resolved_unit = resolve_display_unit(config_entry.data, description.key)
+            sync_registry_suggested_unit(
+                ent_reg, hass, station_upper, description, resolved_unit
+            )
             entities.append(MetarSensor(
                 coordinator=coordinator,
                 station=station_upper,
                 description=description,
                 config_entry=config_entry,
+                suggested_unit=resolved_unit,
             ))
 
         # Setup individual runway sensors (only if we have data with runways)

--- a/tests/test_merge_policy.py
+++ b/tests/test_merge_policy.py
@@ -1,0 +1,160 @@
+"""Regression tests for issue #8: AWC's quantized numerics must not clobber
+exact values derived from the raw METAR string.
+
+AWC's JSON reports visibility in statute miles, capped and quantized ("6+"),
+winds in whole knots (lossy for MPS stations) and altimeter as int hPa (lossy
+for US A-group reports). The raw METAR carries the exact values, so the parser
+wins whenever it produced one; AWC fills in only when the parser found nothing.
+Temperature and dew point stay AWC-first: AWC is never worse than the whole
+degrees of the main group and may carry T-group decimals the parser does not
+read.
+"""
+
+from custom_components.ha_metar_weather.metar_parser import MetarParser
+from custom_components.ha_metar_weather.api_client import merge_awc_numerics
+from custom_components.ha_metar_weather.awc_client import AWCApiClient
+from custom_components.ha_metar_weather.utils import calculate_humidity
+
+
+def _merge(awc_json: dict) -> dict:
+    """Run the real production path: parse_awc_response -> parser -> merge."""
+    awc_meta = AWCApiClient.parse_awc_response(awc_json)
+    parsed = MetarParser(awc_json["rawOb"]).get_parsed_data()
+    return merge_awc_numerics(parsed, awc_meta)
+
+
+# The exact observation from issue #8 (LFLC, 2026-06-09 19:30Z).
+LFLC_JSON = {
+    "icaoId": "LFLC",
+    "name": "Clermont-Ferrand/Auvergne",
+    "rawOb": "METAR LFLC 091930Z AUTO 02003KT 9999 BKN062 16/06 Q1020 NOSIG",
+    "obsTime": 1781033400,
+    "temp": 16,
+    "dewp": 6,
+    "wdir": 20,
+    "wspd": 3,
+    "visib": "6+",
+    "altim": 1020,
+}
+
+
+def test_issue_8_9999_meters_is_10_km():
+    """Raw 9999 means 10 km; AWC's "6+" (9.7 km) must not overwrite it."""
+    merged = _merge(LFLC_JSON)
+    assert merged["visibility"] == 10.0
+
+
+def test_cavok_visibility_not_degraded_by_awc():
+    """CAVOK implies >= 10 km; AWC still sends visib "6+" for such stations."""
+    merged = _merge(
+        {
+            **LFLC_JSON,
+            "rawOb": "METAR LFLC 091930Z AUTO 02003KT CAVOK 16/06 Q1020 NOSIG",
+        }
+    )
+    assert merged["visibility"] == 10.0
+
+
+def test_awc_visibility_used_when_raw_has_none():
+    """Some AUTO reports omit the visibility group; AWC then fills the gap."""
+    merged = _merge(
+        {
+            **LFLC_JSON,
+            "rawOb": "METAR LFLC 091930Z AUTO 02003KT 16/06 Q1020 NOSIG",
+        }
+    )
+    # AWC "6+" -> 6 SM -> 9.7 km, better than nothing
+    assert merged["visibility"] == 9.7
+
+
+def test_mps_wind_not_quantized_to_whole_knots():
+    """AWC converts 8 m/s to 16 kt (29.6 km/h); the raw value is 28.8 km/h."""
+    merged = _merge(
+        {
+            "icaoId": "UUEE",
+            "name": "Sheremetyevo",
+            "rawOb": "UUEE 121630Z 24008MPS 9999 SCT020 18/12 Q1009 NOSIG",
+            "obsTime": 1781000000,
+            "temp": 18,
+            "dewp": 12,
+            "wdir": 240,
+            "wspd": 16,
+            "visib": "6+",
+            "altim": 1009,
+        }
+    )
+    assert merged["wind_speed"] == 28.8  # 8 m/s * 3.6, not 16 kt * 1.852
+
+
+def test_us_altimeter_keeps_tenth_hpa_precision():
+    """A2992 = 1013.2 hPa exactly; AWC's int altim (1013) loses 0.2 hPa."""
+    merged = _merge(
+        {
+            "icaoId": "KJFK",
+            "name": "John F Kennedy Intl",
+            "rawOb": "KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992",
+            "obsTime": 1781000000,
+            "temp": 22,
+            "dewp": 18,
+            "wdir": 180,
+            "wspd": 10,
+            "visib": "10+",
+            "altim": 1013,
+        }
+    )
+    assert merged["pressure"] == 1013.2
+
+
+def test_temperature_and_dew_point_stay_awc_first():
+    """AWC may carry T-group decimals the raw main group lacks."""
+    merged = _merge(
+        {
+            **LFLC_JSON,
+            "temp": 16.4,
+            "dewp": 6.2,
+        }
+    )
+    assert merged["temperature"] == 16.4
+    assert merged["dew_point"] == 6.2
+
+
+def test_humidity_recomputed_from_merged_pair():
+    """Humidity must match whichever temp/dew pair won the merge."""
+    merged = _merge({**LFLC_JSON, "temp": 16.4, "dewp": 6.2})
+    assert merged["humidity"] == calculate_humidity(16.4, 6.2)
+
+
+def test_north_wind_direction_zero_survives_awc_parsing():
+    """wdir=0 with wind blowing is a valid direction, not a missing one."""
+    awc_meta = AWCApiClient.parse_awc_response({**LFLC_JSON, "wdir": 0})
+    assert awc_meta["wind_direction"] == 0.0
+
+
+def test_calm_wind_direction_stays_none():
+    """Calm (00000KT): AWC sends wdir=0/wspd=0, but direction has no meaning.
+
+    The parser deliberately yields None; the AWC fallback must not turn calm
+    into a "north wind", or the AWC and AVWX paths diverge (issue #3).
+    """
+    merged = _merge(
+        {
+            **LFLC_JSON,
+            "rawOb": "METAR LFLC 091930Z AUTO 00000KT 9999 BKN062 16/06 Q1020 NOSIG",
+            "wdir": 0,
+            "wspd": 0,
+        }
+    )
+    assert merged["wind_direction"] is None
+    assert merged["wind_speed"] == 0.0
+
+
+def test_unusable_parser_value_falls_back_to_awc():
+    """A garbled Q-group (Q10133 -> 10133 hPa) fails the later range check;
+    the valid AWC altimeter must fill in instead of the field going None."""
+    merged = _merge(
+        {
+            **LFLC_JSON,
+            "rawOb": "METAR LFLC 091930Z AUTO 02003KT 9999 BKN062 16/06 Q10133 NOSIG",
+        }
+    )
+    assert merged["pressure"] == 1020.0

--- a/tests/test_metar_parser.py
+++ b/tests/test_metar_parser.py
@@ -152,3 +152,39 @@ def test_station_name_falls_back_to_icao():
     """
     data = parse("KJFK 121651Z 18010KT 10SM FEW020 22/18 A2992")
     assert data["station_name"] == "KJFK"
+
+
+def test_temp_dew_survives_fractional_visibility_token():
+    """Regression: "1/2SM" splits to "1"/"2SM" and used to abort the whole
+    temp/dew scan via ValueError, losing the real 12/12 group."""
+    data = parse("KLAX 121651Z 18005KT 1/2SM FG 12/12 A3001")
+    assert data["temperature"] == pytest.approx(12.0)
+    assert data["dew_point"] == pytest.approx(12.0)
+
+
+def test_temp_dew_survives_less_than_fraction_token():
+    data = parse("KLAX 121651Z 18005KT M1/4SM FG 12/12 A3001")
+    assert data["temperature"] == pytest.approx(12.0)
+    assert data["dew_point"] == pytest.approx(12.0)
+
+
+def test_visibility_less_than_fraction():
+    """M1/4SM means "less than 1/4 SM"; report the boundary value."""
+    data = parse("KLAX 121651Z 18005KT M1/4SM FG 12/12 A3001")
+    assert data["visibility"] == pytest.approx(0.4, abs=0.05)
+
+
+def test_visibility_p6sm():
+    data = parse("KJFK 121651Z 18010KT P6SM FEW020 22/18 A2992")
+    assert data["visibility"] == pytest.approx(9.7, abs=0.1)
+
+
+def test_visibility_9999_is_10_km():
+    data = parse("UUEE 121630Z 24008MPS 9999 BKN040 18/12 Q1009 NOSIG")
+    assert data["visibility"] == pytest.approx(10.0)
+
+
+def test_wind_mps_exact_kmh():
+    """8 m/s = 28.8 km/h exactly; must not be quantized through knots."""
+    data = parse("UUEE 121630Z 24008MPS 9999 BKN040 18/12 Q1009 NOSIG")
+    assert data["wind_speed"] == pytest.approx(28.8)

--- a/tests/test_source_consistency.py
+++ b/tests/test_source_consistency.py
@@ -58,15 +58,18 @@ def test_textual_fields_identical_across_sources():
     assert merged["cloud_coverage_state"] == "few"
 
 
-def test_numeric_fields_come_from_awc():
-    """AWC numerics are authoritative (they handle 6+, hPa/inHg, epoch, etc.)."""
+def test_temperature_dew_point_come_from_awc():
+    """Temp/dew stay AWC-first: AWC may carry T-group decimals the raw main
+    group lacks (22.2 vs 22). Parser-first fields are covered by
+    test_merge_policy.py (issue #8)."""
     parsed = MetarParser(RAW).get_parsed_data()
-    merged = merge_awc_numerics(parsed, AWC_META)
+    awc = dict(AWC_META)
+    awc["temperature"] = 22.2
+    awc["dew_point"] = 17.8
+    merged = merge_awc_numerics(parsed, awc)
 
-    assert merged["pressure"] == 1013.0  # AWC value, not the inHg-from-raw value
-    assert merged["visibility"] == 16.1
-    assert merged["temperature"] == 22.0
-    assert merged["humidity"] == 78.0
+    assert merged["temperature"] == 22.2
+    assert merged["dew_point"] == 17.8
 
 
 def test_station_name_and_time_preserved_from_awc():
@@ -94,11 +97,11 @@ def test_out_of_range_awc_numeric_falls_back_to_parser():
     """
     parsed = MetarParser(RAW).get_parsed_data()
     bad_awc = dict(AWC_META)
-    bad_awc["pressure"] = 5000.0  # absurd; outside VALUE_RANGES (900-1100 hPa)
+    bad_awc["temperature"] = 999.0  # absurd; outside VALUE_RANGES (-90..60)
     merged = merge_awc_numerics(parsed, bad_awc)
 
-    assert merged["pressure"] == parsed["pressure"]
-    assert merged["pressure"] != 5000.0
+    assert merged["temperature"] == parsed["temperature"]
+    assert merged["temperature"] != 999.0
 
 
 def test_non_numeric_awc_value_falls_back_to_parser():
@@ -149,6 +152,8 @@ def test_real_awc_path_matches_parser():
     assert merged["weather"] == "heavy_thunderstorm_rain"
     assert merged["pressure"] == 1009.0
     assert merged["station_name"] == "Sheremetyevo"
+    # Issue #8 regression: raw 9999 (10 km) must survive AWC's visib "6+"
+    assert merged["visibility"] == 10.0
 
 
 def test_merge_does_not_mutate_inputs():

--- a/tests/test_unit_preferences.py
+++ b/tests/test_unit_preferences.py
@@ -1,0 +1,206 @@
+"""Tests for issue #7: configured unit preferences must reach Home Assistant.
+
+HA core reads ``suggested_unit_of_measurement`` only BEFORE ``async_added_to_hass``
+(during ``add_to_platform_start`` and registry-entry creation), and for entities
+already present in the entity registry the value is pinned in
+``options["sensor.private"]`` forever. So the integration must (a) set the
+suggestion in ``__init__`` and (b) sync the registry options on every setup for
+entities that already exist - without touching a manual user override stored in
+``options["sensor"]["unit_of_measurement"]``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.sensor import SensorDeviceClass
+
+from custom_components.ha_metar_weather.sensor import (
+    SENSOR_TYPES,
+    MetarSensor,
+    resolve_display_unit,
+    sync_registry_suggested_unit,
+)
+from custom_components.ha_metar_weather.const import DOMAIN
+
+
+DESCRIPTIONS = {d.key: d for d in SENSOR_TYPES}
+
+
+# --- resolve_display_unit: config entry data -> desired display unit ---------
+
+
+def test_resolve_auto_returns_none():
+    """Auto means "let HA decide" - no explicit suggestion."""
+    assert resolve_display_unit({}, "visibility") is None
+    assert resolve_display_unit({"visibility_unit": "auto"}, "visibility") is None
+
+
+def test_resolve_native_metar_units():
+    assert resolve_display_unit({"visibility_unit": "native"}, "visibility") == "mi"
+    assert resolve_display_unit({"wind_speed_unit": "native"}, "wind_speed") == "kn"
+    assert resolve_display_unit({"pressure_unit": "native"}, "pressure") == "hPa"
+    assert (
+        resolve_display_unit({"altitude_unit": "native"}, "cloud_coverage_height")
+        == "ft"
+    )
+
+
+def test_resolve_explicit_unit_passthrough():
+    assert resolve_display_unit({"temperature_unit": "°F"}, "temperature") == "°F"
+    assert resolve_display_unit({"temperature_unit": "°F"}, "dew_point") == "°F"
+    assert resolve_display_unit({"wind_speed_unit": "m/s"}, "wind_gust") == "m/s"
+
+
+def test_resolve_non_unit_sensors_return_none():
+    """Fixed-unit and textual sensors have no configurable display unit."""
+    for key in ("wind_direction", "humidity", "weather", "raw_metar"):
+        assert resolve_display_unit({"temperature_unit": "°F"}, key) is None
+
+
+def test_pressure_sensor_is_atmospheric_pressure():
+    """QNH is atmospheric pressure; device_class PRESSURE would make HA's
+    "auto" pick psi on US installs instead of inHg."""
+    assert (
+        DESCRIPTIONS["pressure"].device_class
+        == SensorDeviceClass.ATMOSPHERIC_PRESSURE
+    )
+
+
+# --- MetarSensor.__init__: suggestion must exist before platform add ---------
+
+
+def _make_sensor(suggested_unit):
+    coordinator = MagicMock()
+    config_entry = MagicMock()
+    config_entry.data = {}
+    return MetarSensor(
+        coordinator=coordinator,
+        station="LFLC",
+        description=DESCRIPTIONS["visibility"],
+        config_entry=config_entry,
+        suggested_unit=suggested_unit,
+    )
+
+
+def test_init_sets_suggested_unit():
+    sensor = _make_sensor("mi")
+    assert sensor.suggested_unit_of_measurement == "mi"
+
+
+def test_init_without_preference_leaves_suggestion_unset():
+    sensor = _make_sensor(None)
+    assert sensor.suggested_unit_of_measurement is None
+
+
+# --- registry sync for already-registered entities ----------------------------
+
+
+def _registry_with(options):
+    ent_reg = MagicMock()
+    entity_id = "sensor.metar_lflc_visibility"
+    ent_reg.async_get_entity_id.return_value = entity_id
+    entry = MagicMock()
+    entry.options = options
+    ent_reg.entities = {entity_id: entry}
+    return ent_reg, entity_id
+
+
+def _hass_with_system_unit(unit):
+    hass = MagicMock()
+    hass.config.units.get_converted_unit.return_value = unit
+    return hass
+
+
+def test_sync_updates_stale_registry_unit():
+    """v3/v4.0.0 installs have the unit-system fallback pinned in the registry;
+    an explicit preference must overwrite it."""
+    ent_reg, entity_id = _registry_with(
+        {"sensor.private": {"suggested_unit_of_measurement": "km"}}
+    )
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit(None), "LFLC", DESCRIPTIONS["visibility"], "mi"
+    )
+    ent_reg.async_update_entity_options.assert_called_once_with(
+        entity_id, "sensor.private", {"suggested_unit_of_measurement": "mi"}
+    )
+
+
+def test_sync_respects_manual_user_override():
+    """A unit the user picked in the HA UI always wins; never touch it."""
+    ent_reg, _ = _registry_with(
+        {
+            "sensor": {"unit_of_measurement": "nmi"},
+            "sensor.private": {"suggested_unit_of_measurement": "km"},
+        }
+    )
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit(None), "LFLC", DESCRIPTIONS["visibility"], "mi"
+    )
+    ent_reg.async_update_entity_options.assert_not_called()
+
+
+def test_sync_noop_when_registry_already_correct():
+    ent_reg, _ = _registry_with(
+        {"sensor.private": {"suggested_unit_of_measurement": "mi"}}
+    )
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit(None), "LFLC", DESCRIPTIONS["visibility"], "mi"
+    )
+    ent_reg.async_update_entity_options.assert_not_called()
+
+
+def test_sync_auto_restores_unit_system_default():
+    """Switching back to "auto" must restore what core itself would store:
+    the unit system's converted unit (e.g. mi on a US install)."""
+    ent_reg, entity_id = _registry_with(
+        {"sensor.private": {"suggested_unit_of_measurement": "km"}}
+    )
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit("mi"), "LFLC", DESCRIPTIONS["visibility"], None
+    )
+    ent_reg.async_update_entity_options.assert_called_once_with(
+        entity_id, "sensor.private", {"suggested_unit_of_measurement": "mi"}
+    )
+
+
+def test_sync_auto_clears_suggestion_when_native_is_system_default():
+    """Auto on a metric install: core stores nothing, so clear the leftovers."""
+    ent_reg, entity_id = _registry_with(
+        {"sensor.private": {"suggested_unit_of_measurement": "mi"}}
+    )
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit(None), "LFLC", DESCRIPTIONS["visibility"], None
+    )
+    ent_reg.async_update_entity_options.assert_called_once_with(
+        entity_id, "sensor.private", {}
+    )
+
+
+def test_sync_skips_unregistered_entity():
+    """New entities get the suggestion via __init__; nothing to sync."""
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = None
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit(None), "LFLC", DESCRIPTIONS["visibility"], "mi"
+    )
+    ent_reg.async_update_entity_options.assert_not_called()
+
+
+def test_sync_skips_non_unit_sensor():
+    ent_reg, _ = _registry_with({})
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit(None), "LFLC", DESCRIPTIONS["weather"], None
+    )
+    ent_reg.async_get_entity_id.assert_not_called()
+    ent_reg.async_update_entity_options.assert_not_called()
+
+
+def test_sync_looks_up_by_stable_unique_id():
+    ent_reg, _ = _registry_with({})
+    sync_registry_suggested_unit(
+        ent_reg, _hass_with_system_unit(None), "LFLC", DESCRIPTIONS["visibility"], "mi"
+    )
+    ent_reg.async_get_entity_id.assert_called_once_with(
+        "sensor", DOMAIN, f"{DOMAIN}_LFLC_visibility"
+    )


### PR DESCRIPTION
Fixes #7, fixes #8. Both reported against the v4.0.0 pre-release.

## Issue #8: 9999 m shown as 9.7 km

AWC's JSON quantizes what the raw METAR states exactly: `visib` is capped statute miles (`"6+"` = 9.7 km even when the report says `9999` or CAVOK = 10 km), winds are whole knots (lossy for MPS stations, up to ~0.9 km/h), the altimeter is int hPa (`A2992` is 1013.2 hPa, not 1013). `merge_awc_numerics` treated all AWC numerics as authoritative, so the quantized values overwrote the exact ones.

The merge policy is now split:
- **parser-first** (AWC fills in only when the parser found nothing usable): wind speed/direction/gust, visibility, pressure
- **AWC-first**: temperature, dew point (AWC is never worse than the whole-degree main group and may carry T-group decimals the parser does not read)
- humidity is recomputed from whichever temperature/dew point pair won the merge

Related fixes surfaced by the audit:
- `_parse_temp_dew` no longer aborts the entire scan when a fractional visibility token (`1/2SM`) splits into something `float()` rejects - US fog reports were losing temperature on the AVWX fallback path
- fractional visibility accepts the `M` ("less than") prefix: `M1/4SM`
- calm wind from AWC (`wdir=0, wspd=0`) maps to direction `None`, matching the parser; a true north wind (`wdir=0` with wind blowing) is kept instead of being dropped as falsy

## Issue #7: configured units ignored

Unit preferences never worked in v3.0.0-v4.0.0. The suggested unit was assigned in `async_added_to_hass`, but HA core reads `suggested_unit_of_measurement` only **before** that hook (`add_to_platform_start` and registry-entry creation) and pins the result in entity registry options forever - for registered entities the late assignment is dead code in every path, so sensors always showed the HA unit-system default.

Now:
- the suggestion is resolved up front and set in `__init__`, so new entities register with the configured unit
- `sync_registry_suggested_unit()` rewrites the pinned value in registry `options["sensor.private"]` on every setup, so existing installs pick up preference changes on reload
- a unit picked manually in the HA UI (`options["sensor"]["unit_of_measurement"]`) always wins and is never touched
- `auto` mirrors core's own unit-system fallback (`get_converted_unit`)
- the pressure sensor's device class is now `atmospheric_pressure` (QNH): `auto` on US installs reads inHg instead of psi

## Release-note caveats for v4.0.1

- the pressure sensor's `attributes.device_class` changes `pressure` -> `atmospheric_pressure`; automations/templates filtering on it need updating (long-term statistics are unaffected - same unit class and converter)
- US installs with `auto` units: pressure display changes psi -> inHg (intended)
- unit preferences now actually apply, so displayed units may change after upgrade unless manually overridden in the UI

## Testing

- 70 tests pass (`tests/`): new `test_merge_policy.py` (production-path regressions for #8 incl. CAVOK, MPS wind, A-group precision, calm wind, garbled Q-group fallback) and `test_unit_preferences.py` (resolve/sync logic for #7), plus parser regressions
- merge behavior verified against the live AWC response for LFLC (the exact observation from #8)
- HA core semantics verified against home-assistant/core dev and the installed 2026.2.3 package