### PR TITLE
fix: report missing METAR fields as unknown instead of unavailable (#13)

### DIFF
--- a/custom_components/ha_metar_weather/sensor.py
+++ b/custom_components/ha_metar_weather/sensor.py
@@ -658,30 +658,19 @@ class MetarSensor(CoordinatorEntity, SensorEntity):
             return TrendState.STABLE
 
 
-    @property
+   @property
     def available(self) -> bool:
-        """Return if entity is available."""
-        if not self.coordinator.last_update_success or self.coordinator.data is None:
-            return False
+        """Return if entity is available.
 
-        key = self.entity_description.key
-
-        # wind_direction: available only if we have a numeric direction
-        # For VRB wind, direction is None - sensor will be unavailable
-        # The separate wind_variable_direction sensor shows "VRB" status
-        if key == "wind_direction":
-            return self.coordinator.data.get("wind_direction") is not None
-
-        # wind_gust: only available if there's actually a gust value
-        if key == "wind_gust":
-            return self.coordinator.data.get("wind_gust") is not None
-
-        # wind_variable_direction: only available if there's variable direction
-        if key == "wind_variable_direction":
-            return self.coordinator.data.get("wind_variable_direction") is not None
-
-        return self.native_value is not None
-
+        The entity is available whenever the coordinator has fresh data,
+        even if this specific field is absent from the current METAR
+        (e.g. no wind direction when calm, no cloud height under CAVOK).
+        Those legitimate "no value" cases are reported via native_value
+        returning None, which HA renders as "unknown" (grey, no warning)
+        rather than "unavailable" (warning icon) - see issue #13.
+        """
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+        
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
Closes #13

## What this PR does
Changes MetarSensor.available so that legitimately-absent METAR fields 
(no wind direction when calm, no wind gust, no variable direction, no 
cloud height under CAVOK, etc.) report as `unknown` instead of 
`unavailable`.

## Why
`unavailable` triggers warning indicators on most Lovelace cards, even 
though "no wind direction because there's no wind" is normal, expected 
data - not a sensor fault. `unknown` displays the same grey/inactive 
state without the warning, which is the correct UX for this case.

## Before
available returned False whenever wind_direction / wind_gust / 
wind_variable_direction / native_value was None, even on a successful 
coordinator update -> entity shows as "Unavailable" with a warning icon.

## After
available is True whenever the coordinator update succeeded and has 
data. native_value still returns None for absent fields, which HA 
renders as "unknown" (grey, no warning).